### PR TITLE
Refactor: 데이터 업데이트 로직 리팩토링

### DIFF
--- a/src/features/paintCanvas/hooks/useDrawCanvas.ts
+++ b/src/features/paintCanvas/hooks/useDrawCanvas.ts
@@ -45,11 +45,6 @@ const useDrawCanvas = (storage: TotalPaintInfoType) => {
     setTotalPaintInfo((prev) => ({ ...prev, data: newData }));
   };
 
-  // 삭제해줘야한다.
-  const updateTotalPaintInfo = (updateState: PaintDataType[]) => {
-    setTotalPaintInfo((prev) => ({ ...prev, data: updateState }));
-  };
-
   const getUpdateLastType = (
     lastCurveIndex: number,
     type: Omit<keyof typeof paintInfo.PAINT_TYPE, ''>
@@ -97,7 +92,6 @@ const useDrawCanvas = (storage: TotalPaintInfoType) => {
   return {
     totalPaintInfo,
     setTotalPaintInfo,
-    updateTotalPaintInfo,
     updateTotal,
     getUpdateLastType,
     updateFindTotal,

--- a/src/features/paintCanvas/hooks/useDrawCanvas.ts
+++ b/src/features/paintCanvas/hooks/useDrawCanvas.ts
@@ -23,29 +23,60 @@ const useDrawCanvas = (storage: TotalPaintInfoType) => {
   const [totalPaintInfo, setTotalPaintInfo] =
     useState<TotalPaintInfoType>(storage);
 
+  const updateFindTotal = <T extends PaintDataType>(
+    targetIndex: number,
+    updateState: T
+  ) => {
+    const newData = totalPaintInfo.data.map((shape, index) =>
+      index === targetIndex ? updateState : shape
+    );
+
+    setTotalPaintInfo((prev) => ({ ...prev, data: [...newData] }));
+  };
+
+  const updateTotal = <T extends PaintDataType>(
+    updateState: T,
+    isRemove: boolean = false
+  ) => {
+    const newData = isRemove
+      ? totalPaintInfo.data.slice(0, -1).concat(updateState as T)
+      : totalPaintInfo.data.concat(updateState as T);
+
+    setTotalPaintInfo((prev) => ({ ...prev, data: newData }));
+  };
+
+  // 삭제해줘야한다.
   const updateTotalPaintInfo = (updateState: PaintDataType[]) => {
-    setTotalPaintInfo((prev) => ({ ...prev, data: [...updateState] }));
+    setTotalPaintInfo((prev) => ({ ...prev, data: updateState }));
   };
 
-  const getCurvePaintInfo = (lastCurveIndex: number) => {
-    const actualIndex = totalPaintInfo.data.length - 1 - lastCurveIndex;
-    const lastCurve = totalPaintInfo.data[actualIndex] as CurveListType;
+  const getUpdateLastType = (
+    lastCurveIndex: number,
+    type: Omit<keyof typeof paintInfo.PAINT_TYPE, ''>
+  ) => {
+    switch (type) {
+      case paintInfo.PAINT_TYPE.curve: {
+        const lastData = totalPaintInfo.data[lastCurveIndex] as CurveListType;
 
-    const pathData = `M ${lastCurve.x1} ${lastCurve.y1} Q ${lastCurve.controlX} ${lastCurve.controlY} ${lastCurve.x2} ${lastCurve.y2}`;
+        const pathData = `M ${lastData.x1} ${lastData.y1} Q ${lastData.controlX} ${lastData.controlY} ${lastData.x2} ${lastData.y2}`;
 
-    const updatedCurve = {
-      ...lastCurve,
-      state: 'curve',
-      d: pathData,
-    };
-
-    return {
-      actualIndex,
-      updatedCurve,
-    };
+        return {
+          ...lastData,
+          state: 'curve',
+          d: pathData,
+        };
+      }
+      case paintInfo.PAINT_TYPE.polygon: {
+        const lastData = totalPaintInfo.data[lastCurveIndex] as PolygonListType;
+        return lastData;
+      }
+    }
   };
 
-  const getTypeLastIndex = (type: keyof typeof paintInfo.PAINT_TYPE) => {
+  const getTypeLastIndex = (
+    type: Omit<keyof typeof paintInfo.PAINT_TYPE, ''>,
+    state?: string
+  ) => {
     if (type === paintInfo.PAINT_TYPE.polygon)
       return totalPaintInfo.data.findIndex(
         (shape) =>
@@ -56,7 +87,7 @@ const useDrawCanvas = (storage: TotalPaintInfoType) => {
       return totalPaintInfo.data.findIndex(
         (shape) =>
           shape.type === paintInfo.PAINT_TYPE.curve &&
-          (shape as CurveListType).state === 'dashLine'
+          (shape as CurveListType).state === state
       );
   };
 
@@ -67,7 +98,9 @@ const useDrawCanvas = (storage: TotalPaintInfoType) => {
     totalPaintInfo,
     setTotalPaintInfo,
     updateTotalPaintInfo,
-    getCurvePaintInfo,
+    updateTotal,
+    getUpdateLastType,
+    updateFindTotal,
     getTypeLastIndex,
     lastShape,
   };

--- a/src/features/paintCanvas/ui.tsx
+++ b/src/features/paintCanvas/ui.tsx
@@ -41,7 +41,6 @@ const DrawingCanvas = () => {
   const {
     totalPaintInfo,
     setTotalPaintInfo,
-    updateTotalPaintInfo,
     updateTotal,
     updateFindTotal,
     getUpdateLastType,
@@ -114,7 +113,7 @@ const DrawingCanvas = () => {
           height: 0,
         };
 
-        updateTotal<RectListType>(newData);
+        updateTotal(newData);
 
         break;
       }

--- a/src/shared/types/paintType.ts
+++ b/src/shared/types/paintType.ts
@@ -44,8 +44,8 @@ export interface CurveListType extends DrawingInfoProps {
   y1: number;
   x2: number;
   y2: number;
-  controlX: number;
-  controlY: number;
   state: string;
-  d: string;
+  controlX?: number;
+  controlY?: number;
+  d?: string;
 }


### PR DESCRIPTION
### 무엇을 변경했는지?
-  기존에 데이터 찾는 로직과 업데이트 하는 훅으로 통해서 로직을 분리하였습니다.

 기존에 진행했던 방식 
```typescript
        const newData = totalPaintInfo.data.concat({
         ...newShape,
          x,
          y,
           width: 0,
           height: 0,
        } as RectListType);

         updateTotalPaintInfo(newData);
``` 
변경된 방식
```typescript
        const newData = {
          ...newShape,
          x,
          y,
          width: 0,
          height: 0,
        };

        updateTotal(newData);
``` 
### 장점
- 어떤 데이터를 업데이트 하고싶은지만 넘겨주면 되는 로직으로 수정 -> 데이터 일관성 유지
- 데이터 로직을 수정하고 싶다면 해당 훅에서만 고쳐주면 된다 -> 접근의 용의성

### 아쉬운 점
- 과제가 끝난후에도 아쉬움이 있어서 시간을 내어서 해결했습니다.다만, 이걸 좀만 더 고민해서 빨리 적용했다면 이런 아쉬움이 있습니다.🥲